### PR TITLE
Dynamically get data for blade directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Getting data for blade directive
+- Getting data for blade directive [2]
 
 ## v1.0.2
 
@@ -23,3 +23,5 @@
 ### Added
 
 - First release
+
+[2]:https://github.com/avto-dev/back2front-laravel/issues/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.x.x
+
+### Fixed
+
+- Getting data for blade directive
+
 ## v1.0.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## v1.x.x
+## v1.0.3
 
 ### Fixed
 
-- Getting data for blade directive [2]
+- Getting data for blade directive [#2]
+
+[#2]:https://github.com/avto-dev/back2front-laravel/issues/2
 
 ## v1.0.2
 
@@ -23,5 +25,3 @@
 ### Added
 
 - First release
-
-[2]:https://github.com/avto-dev/back2front-laravel/issues/2

--- a/src/StackServiceProvider.php
+++ b/src/StackServiceProvider.php
@@ -87,14 +87,19 @@ class StackServiceProvider extends ServiceProvider
                     ? $stack_name
                     : $config->get(static::getConfigRootKeyName() . '.stack_name'));
 
-                $tag_text = '<script type="text/javascript">' .
-                            'Object.defineProperty(window, "' . $stack_name . '", {' .
-                            'writable: false, ' .
-                            'value:  \', resolve( ' . BackendToFrontendVariablesInterface::class . '::class )->toJson() , \' ' .
-                            '});' .
-                            '</script>';
-
-                return "<?php echo '{$tag_text}'; ?>";
+                return \sprintf(
+                    '<?php echo \'<script type="text/javascript">
+                                Object.defineProperty(
+                                    window, "%s", 
+                                    {
+                                        writable: false, 
+                                        value:  \', resolve( \'%s\' )->toJson() , \' 
+                                    }
+                                );
+                            </script>\'; ?>',
+                    $stack_name,
+                    BackendToFrontendVariablesInterface::class
+                );
             });
         });
     }

--- a/src/StackServiceProvider.php
+++ b/src/StackServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace AvtoDev\BackendToFrontendVariablesStack;
 
@@ -87,12 +87,12 @@ class StackServiceProvider extends ServiceProvider
                     ? $stack_name
                     : $config->get(static::getConfigRootKeyName() . '.stack_name'));
 
-                $tag_text   = '<script type="text/javascript">' .
-                              'Object.defineProperty(window, "' . $stack_name . '", {' .
-                              'writable: false, ' .
-                              'value:  \', backToFrontStack()->toJson() , \' '.
-                              '});' .
-                              '</script>';
+                $tag_text = '<script type="text/javascript">' .
+                            'Object.defineProperty(window, "' . $stack_name . '", {' .
+                            'writable: false, ' .
+                            'value:  \', resolve( ' . BackendToFrontendVariablesInterface::class . '::class )->toJson() , \' ' .
+                            '});' .
+                            '</script>';
 
                 return "<?php echo '{$tag_text}'; ?>";
             });

--- a/src/StackServiceProvider.php
+++ b/src/StackServiceProvider.php
@@ -80,8 +80,6 @@ class StackServiceProvider extends ServiceProvider
     {
         $this->app->afterResolving('blade.compiler', function (BladeCompiler $blade) {
             $blade->directive('back_to_front_data', function ($stack_name = null) {
-                /** @var BackendToFrontendVariablesInterface $service */
-                $service = $this->app->make(BackendToFrontendVariablesInterface::class);
                 /** @var ConfigRepository $config */
                 $config = $this->app->make(ConfigRepository::class);
 
@@ -92,7 +90,7 @@ class StackServiceProvider extends ServiceProvider
                 $tag_text   = '<script type="text/javascript">' .
                               'Object.defineProperty(window, "' . $stack_name . '", {' .
                               'writable: false, ' .
-                              'value: ' . $service->toJson() .
+                              'value:  \', backToFrontStack()->toJson() , \' '.
                               '});' .
                               '</script>';
 

--- a/tests/php/Unit/BladeRenderTest.php
+++ b/tests/php/Unit/BladeRenderTest.php
@@ -78,9 +78,6 @@ class BladeRenderTest extends AbstractTestCase
 
         $this->assertContains( 'foo', $rendered);
 
-        // Cache all templates
-        $this->artisan('view:cache');
-
         // Set another state
         $service->put('test_key', 'bar2');
         $service->forget('foo');

--- a/tests/php/Unit/BladeRenderTest.php
+++ b/tests/php/Unit/BladeRenderTest.php
@@ -56,4 +56,39 @@ class BladeRenderTest extends AbstractTestCase
             $this->assertContains((string) $value, $rendered);
         }
     }
+
+    /**
+     * Rendering test.
+     *
+     * @return void
+     */
+    public function testRenderCaching()
+    {
+        /** @var BackendToFrontendVariablesInterface $service */
+        $service = $this->app->make(BackendToFrontendVariablesInterface::class);
+        /** @var ViewFactory $view */
+        $view = $this->app->make(ViewFactory::class);
+
+        $view->addNamespace('stubs', __DIR__ . '/../stubs/view');
+
+        // Set first state
+        $service->put('foo', 'bar');
+
+        $rendered = $view->make('stubs::view')->render();
+
+        $this->assertContains( 'foo', $rendered);
+
+        // Cache all templates
+        $this->artisan('view:cache');
+
+        // Set another state
+        $service->put('test_key', 'bar2');
+        $service->forget('foo');
+
+        $rendered2 = $view->make('stubs::view')->render();
+
+        // See actual data
+        $this->assertNotContains( 'foo', $rendered2);
+        $this->assertContains('test_key', $rendered2);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

Результат вызова blade директивы @back_to_front_data кэшируется когда она вызывается в первый раз. Затем при переходе на другую страницу результат берется из кэша даже если в сервисе установлены другие данные. 
Директива переделана так, чтобы вызывался код backToFrontStack()->toJson(), из того места и в тот момент когда итоговый скрипт обрабатывается PHP интерпретатором.

Fixes [#2](https://github.com/avto-dev/back2front-laravel/issues/2)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/back2front-laravel/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v1.x.x`, if it does not exists
> * Add description under `added`/`changed`/`fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document