### PR TITLE
update illuminate up to 6.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Fixes # (issue)
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I wrote unit tests for my code
+- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
 - [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/back2front-laravel/blob/master/CHANGELOG.md) file
 
 <!--

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -1,0 +1,46 @@
+name: Execute tests
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '**'
+  pull_request:
+
+jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
+  tests:
+    name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        setup: ['basic', 'lowest']
+        php: ['7.1', '7.2', '7.3']
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@master # Action page: <https://github.com/shivammathur/setup-php>
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install Composer 'hirak/prestissimo' package
+        run: composer global require hirak/prestissimo --update-no-dev
+
+      - name: Install lowest Composer dependencies
+        if: matrix.setup == 'lowest'
+        run: composer update --prefer-dist --no-interaction --no-suggest --prefer-lowest
+
+      - name: Install basic Composer dependencies
+        if: matrix.setup == 'basic'
+        run: composer update --prefer-dist --no-interaction --no-suggest
+
+      - name: Show most important packages versions
+        run: composer info | grep -e laravel/laravel -e phpunit/phpunit -e phpstan/phpstan
+
+      - name: Execute tests
+        run: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,20 @@ after_success:
 
 matrix:
   include:
+    - language: node_js
+      cache:
+        yarn: true
+        directories:
+          - node_modules
+      node_js: stable
+      install:
+        - npm install -g codecov
+        - yarn install
+      script:
+        - yarn test-cover
+      after_success:
+        - codecov
+
     - php: 7.1.3
       env: setup=lowest
     - php: 7.1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,42 +35,34 @@ after_success:
 
 matrix:
   include:
-    - language: node_js
-      cache:
-        yarn: true
-        directories:
-          - node_modules
-      node_js: stable
-      install:
-        - npm install -g codecov
-        - yarn install
-      script:
-        - yarn test-cover
-      after_success:
-        - codecov
-
     - php: 7.1.3
       env: setup=lowest
     - php: 7.1.3
-      env: laravel=5.6
+      env: laravel=5.5
     - php: 7.1.3
-      env: laravel=5.7
+      env: laravel=5.6
     - php: 7.1.3
       env: coverage=true
 
     - php: 7.2
       env: setup=lowest
     - php: 7.2
-      env: coverage=true
+      env: laravel=5.8
+    - php: 7.2
+      env: coverage=true laravel=6.*
 
     - php: 7.3
       env: setup=lowest
+    - php: 7.3
+      env: laravel=5.5
     - php: 7.3
       env: laravel=5.6
     - php: 7.3
       env: laravel=5.7
     - php: 7.3
-      env: coverage=true
+      env: laravel=5.8
+    - php: 7.3
+      env: coverage=true laravel=6.*
 
     - php: nightly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## Unreleased
+## v2.1.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Maximal `illuminate/*` packages version now is `6.*`
 
+### Added
+
+- GitHub actions for a tests running
+
 ## v2.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Added support laravel/framework ^6.0
+
 ## v2.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## Unreleased
 
-### Added
+### Changed
 
-- Added support laravel/framework ^6.0
+- Maximal `illuminate/*` packages version now is `6.*`
 
 ## v2.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:1.8.6 AS composer
 
-FROM php:7.1.3-alpine
+FROM php:7.2.0-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/support": ">=5.5.0 <5.9.0",
-        "illuminate/view": ">=5.5.0 <5.9.0",
-        "illuminate/container": ">=5.5.0 <5.9.0",
-        "illuminate/config": ">=5.5.0 <5.9.0",
+        "illuminate/support": ">=5.5.0 <5.9.0 || ~6.0",
+        "illuminate/view": ">=5.5.0 <5.9.0 || ~6.0",
+        "illuminate/container": ">=5.5.0 <5.9.0 || ~6.0",
+        "illuminate/config": ">=5.5.0 <5.9.0 || ~6.0",
         "tarampampam/wrappers-php": "^1.3"
     },
     "require-dev": {
-        "laravel/laravel": ">=5.5.0 <5.9.0",
+        "laravel/laravel": ">=5.5.0 <5.9.0 || ~6.0",
         "phpstan/phpstan": "^0.11.3",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.4 || ~7.5"

--- a/tests/php/Unit/Back2FrontStackTest.php
+++ b/tests/php/Unit/Back2FrontStackTest.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace AvtoDev\Back2Front\Tests\Unit;
 
 use DateTime;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Tarampampam\Wrappers\Json;
 use AvtoDev\Back2Front\Back2FrontInterface;
 use Illuminate\Contracts\Support\Arrayable;
@@ -81,16 +83,16 @@ class Back2FrontStackTest extends AbstractTestCase
     public function testToArrayDeepScalar(): void
     {
         $deep_array               = [];
-        $test_deep_array_scalar   = str_random();
+        $test_deep_array_scalar   = Str::random();
         $test_deep_array_key_path = '0.test.1.4.A.#test.88';
 
-        array_set($deep_array, $test_deep_array_key_path, $test_deep_array_scalar);
+        Arr::set($deep_array, $test_deep_array_key_path, $test_deep_array_scalar);
 
         $this->service->put('test_deep', $deep_array);
 
         $result = $this->service->toArray();
 
-        $this->assertEquals($test_deep_array_scalar, array_get($result, 'test_deep.' . $test_deep_array_key_path));
+        $this->assertEquals($test_deep_array_scalar, Arr::get($result, 'test_deep.' . $test_deep_array_key_path));
     }
 
     /**
@@ -102,7 +104,7 @@ class Back2FrontStackTest extends AbstractTestCase
 
         $result = $this->service->toArray();
 
-        $this->assertNull(array_get($result, 'test_obj'));
+        $this->assertNull(Arr::get($result, 'test_obj'));
     }
 
     /**
@@ -130,13 +132,13 @@ class Back2FrontStackTest extends AbstractTestCase
         $test_deep_array_object   = new \stdClass;
         $test_deep_array_key_path = '0.test.1.4.A.#test.88';
 
-        array_set($deep_array, $test_deep_array_key_path, $test_deep_array_object);
+        Arr::set($deep_array, $test_deep_array_key_path, $test_deep_array_object);
 
         $this->service->put('test_deep', $deep_array);
 
         $result = $this->service->toArray();
 
-        $this->assertNull(array_get($result, 'test_deep.' . $test_deep_array_key_path));
+        $this->assertNull(Arr::get($result, 'test_deep.' . $test_deep_array_key_path));
     }
 
     /**
@@ -156,7 +158,7 @@ class Back2FrontStackTest extends AbstractTestCase
 
         $result = $this->service->toArray();
 
-        $this->assertEquals([1, 2, 3], array_get($result, 'test_arrayable'));
+        $this->assertEquals([1, 2, 3], Arr::get($result, 'test_arrayable'));
     }
 
     /**
@@ -164,11 +166,11 @@ class Back2FrontStackTest extends AbstractTestCase
      */
     public function testPutGetToJson(): void
     {
-        $test_data[]             = [str_random(), random_int(0, 100)];
+        $test_data[]             = [Str::random(), random_int(0, 100)];
         $test_data[]             = random_int(-10, 10);
         $test_data[]             = null;
-        $test_data[str_random()] = str_random();
-        $test_data[-10]          = str_random();
+        $test_data[Str::random()] = Str::random();
+        $test_data[-10]          = Str::random();
         $test_data['collection'] = collect([1]);
 
         foreach ($test_data as $key => $value) {
@@ -200,12 +202,12 @@ class Back2FrontStackTest extends AbstractTestCase
      */
     public function testHas(): void
     {
-        $test_key = str_random();
+        $test_key = Str::random();
 
         $this->service->put($test_key, 1);
 
         $this->assertTrue($this->service->has($test_key));
-        $this->assertFalse($this->service->has(str_random()));
+        $this->assertFalse($this->service->has(Str::random()));
     }
 
     /**
@@ -213,7 +215,7 @@ class Back2FrontStackTest extends AbstractTestCase
      */
     public function testForget(): void
     {
-        $test_key = str_random();
+        $test_key = Str::random();
 
         $this->service->put($test_key, 1);
 

--- a/tests/php/Unit/Back2FrontStackTest.php
+++ b/tests/php/Unit/Back2FrontStackTest.php
@@ -166,12 +166,12 @@ class Back2FrontStackTest extends AbstractTestCase
      */
     public function testPutGetToJson(): void
     {
-        $test_data[]             = [Str::random(), random_int(0, 100)];
-        $test_data[]             = random_int(-10, 10);
-        $test_data[]             = null;
+        $test_data[]              = [Str::random(), random_int(0, 100)];
+        $test_data[]              = random_int(-10, 10);
+        $test_data[]              = null;
         $test_data[Str::random()] = Str::random();
-        $test_data[-10]          = Str::random();
-        $test_data['collection'] = collect([1]);
+        $test_data[-10]           = Str::random();
+        $test_data['collection']  = collect([1]);
 
         foreach ($test_data as $key => $value) {
             $this->service->put($key, $value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No

## Description

### Changed

- Maximal `illuminate/*` packages version now is `6.*`

### Added

- GitHub actions for a tests running

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/back2front-laravel/blob/master/CHANGELOG.md) file

