### PR TITLE
Add support Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^7.0'
+        php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,10 +34,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -73,7 +68,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -86,12 +81,12 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v1 # Action page: <https://github.com/actions/setup-node>
+        uses: actions/setup-node@v3 # Action page: <https://github.com/actions/setup-node>
         with:
-          node-version: '12'
+          node-version: '16'
 
       - name: Install dependencies
         run: yarn install
@@ -99,7 +94,7 @@ jobs: # Docs: <https://git.io/JvxXE>
       - name: Execute tests
         run: yarn test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/js/clover.xml
@@ -108,10 +103,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal Laravel version now is `9.0`
+- Minimal `phpstan/phpstan` version now is `1.9`
+- Minimal `mockery/mockery` version now is `1.5.1`
+- Minimal `phpunit/phpunit` version now is `9.6`
+- Version of `composer` in docker container updated up to `2.5.3`
+
 ## v2.5.0
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5.3 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.0.0 1>/dev/null \
+    && pecl install xdebug-3.2.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/view": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/container": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/config": "~6.0 || ~7.0 || ~8.0"
+        "illuminate/support": "~9.0",
+        "illuminate/view": "~9.0",
+        "illuminate/container": "~9.0",
+        "illuminate/config": "~9.0"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
-        "phpstan/phpstan": "~0.12.36",
-        "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^8.5.4 || ^9.3"
+        "laravel/laravel": "~9.0",
+        "phpstan/phpstan": "~1.9",
+        "mockery/mockery": "^1.5.1",
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 parameters:
   level: 'max'
+  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="./tests/php/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
+         forceCoversAnnotation="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+        </exclude>
+        <report>
+            <clover outputFile="./coverage/php/clover.xml"/>
+            <text outputFile="php://stdout"/>
+            <xml outputDirectory="./coverage/php/xml"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/php</directory>
+            <directory>./tests/php</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!--log type="coverage-html" target="./coverage/php/html"/-->
-        <log type="coverage-xml" target="./coverage/php/xml"/>
-        <log type="coverage-clover" target="./coverage/php/clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-    </logging>
 </phpunit>

--- a/src/Back2FrontStack.php
+++ b/src/Back2FrontStack.php
@@ -34,10 +34,11 @@ class Back2FrontStack extends Collection implements Back2FrontInterface
     {
         parent::__construct();
 
-        $config_root = ServiceProvider::getConfigRootKeyName();
+        /** @var array{date_format: string|null,max_recursion_depth: int|null, stack_name: string|null} $values */
+        $values = $config->get(ServiceProvider::getConfigRootKeyName());
 
-        $this->date_format         = (string) $config->get("{$config_root}.date_format", 'Y-m-d H:i:s');
-        $this->max_recursion_depth = (int) $config->get("{$config_root}.max_recursion_depth", 3);
+        $this->date_format         = $values['date_format'] ?? 'Y-m-d H:i:s';
+        $this->max_recursion_depth = $values['max_recursion_depth'] ?? 3;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -112,9 +112,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 /** @var ConfigRepository $config */
                 $config = $this->app->make(ConfigRepository::class);
 
-                $stack_name = Str::slug((\is_string($stack_name) && $stack_name !== '')
+                /** @var string $stack_name */
+                $stack_name = (\is_string($stack_name) && $stack_name !== '')
                     ? $stack_name
-                    : $config->get(static::getConfigRootKeyName() . '.stack_name'));
+                    : $config->get(static::getConfigRootKeyName() . '.stack_name');
+
+                $stack_name = Str::slug($stack_name);
 
                 return \sprintf(
                     '<?php echo \'<script type="text/javascript">

--- a/tests/php/Unit/BladeRenderTest.php
+++ b/tests/php/Unit/BladeRenderTest.php
@@ -40,7 +40,7 @@ class BladeRenderTest extends AbstractTestCase
 
         $rendered = $view->make('stubs::view')->render();
 
-        $this->assertRegExp("~window,\s?['\"]{$config->get('back-to-front.stack_name')}['\"],~", $rendered);
+        $this->assertMatchesRegularExpression("~window,\s?['\"]{$config->get('back-to-front.stack_name')}['\"],~", $rendered);
 
         foreach ($data as $key => $value) {
             $this->assertStringContainsString((string) $key, $rendered);


### PR DESCRIPTION
## Description

### Changed

- Minimal Laravel version now is `9.0`
- Minimal `phpstan/phpstan` version now is `1.9`
- Minimal `mockery/mockery` version now is `1.5.1`
- Minimal `phpunit/phpunit` version now is `9.6`
- Version of `composer` in docker container updated up to `2.5.3`

Closes #12 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
