### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.2', '8.3']
+        php: ['8.3', '8.4']
         include:
-          - php: '8.2'
+          - php: '8.3'
             setup: [ basic, lowest ]
             coverage: no
-            laravel: '^10.0'
+            laravel: '^11.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         php: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -37,7 +37,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -68,11 +68,11 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/php/clover.xml
+          files: ./coverage/php/clover.xml
           flags: php
           fail_ci_if_error: false
 
@@ -81,7 +81,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4 # Action page: <https://github.com/actions/setup-node>
@@ -94,10 +94,10 @@ jobs: # Docs: <https://git.io/JvxXE>
       - name: Execute tests
         run: yarn test-cover
 
-      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/js/clover.xml
+          files: ./coverage/js/clover.xml
           flags: js
           fail_ci_if_error: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '8.3'
             setup: [ basic, lowest ]
             coverage: no
-            laravel: '^11.0'
+            laravel: '^12.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '8.3'
             setup: [ basic, lowest ]
             coverage: no
-            laravel: '^12.0'
+            laravel: '^11.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
         include:
           - php: '8.3'
             setup: [ basic, lowest ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,6 @@ jobs: # Docs: <https://git.io/JvxXE>
         laravel: [default]
         coverage: [yes]
         php: ['8.3', '8.4', '8.5']
-        include:
-          - php: '8.3'
-            setup: [ basic, lowest ]
-            coverage: no
-            laravel: '^11.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         uses: actions/checkout@v7
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v4 # Action page: <https://github.com/actions/setup-node>
+        uses: actions/setup-node@v7 # Action page: <https://github.com/actions/setup-node>
         with:
           node-version: '16'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Minimal required PHP version now is `8.3`
 - Minimal Laravel version now is `^11.0`
 - Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Minimal Laravel version now is `^12.0`
 - Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.4`
-- Version of `phpstan/phpstan` version now is `2.1.54`
+- Update dev dependencies
 
 ## v2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Minimal required PHP version now is `8.3`
 - Minimal Laravel version now is `11.0`
 - Version of `composer` in docker container updated up to `2.10.0`
-- Updated dev dependencies
+- Version of `php` in docker container updated up to `8.4`
+- Version of `phpstan/phpstan` version now is `2.1.54`
 
 ## v2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal required PHP version now is `8.3`
-- Minimal Laravel version now is `^11.54.0`
+- Minimal Laravel version now is `^12.0`
 - Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.4`
 - Version of `phpstan/phpstan` version now is `2.1.54`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal required PHP version now is `8.3`
-- Minimal Laravel version now is `^12.0`
+- Minimal Laravel version now is `^11.0`
 - Version of `composer` in docker container updated up to `2.10.0`
-- Version of `php` in docker container updated up to `8.4`
+- Version of `php` in docker container updated up to `8.5`
+- Minimal `phpunit/phpunit` version now is `^10.5.35`
 - Update dev dependencies
 
 ## v2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal required PHP version now is `8.3`
-- Minimal Laravel version now is `11.0`
+- Minimal Laravel version now is `^11.54.0`
 - Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.4`
 - Version of `phpstan/phpstan` version now is `2.1.54`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `13.x` support
+
+### Changed
+
+- Minimal required PHP version now is `8.3`
+- Minimal Laravel version now is `11.0`
+- Version of `composer` in docker container updated up to `2.10.0`
+- Updated dev dependencies
+
 ## v2.9.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-alpine
+FROM php:8.5-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.5-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.10.0 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-alpine
+FROM php:8.4-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM php:8.3-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.10.0 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.3.0 1>/dev/null \
+    && pecl install xdebug-3.5.3 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,16 @@
         "php": "^8.3",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "illuminate/support": "^12.0 || ^13.0",
-        "illuminate/view": "^12.0 || ^13.0",
-        "illuminate/container": "^12.0 || ^13.0",
-        "illuminate/config": "^12.0 || ^13.0"
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/view": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/container": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/config": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "laravel/laravel": "^12.0 || ^13.0",
-        "laravel/framework": "^12.0 || ^13.0",
+        "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
         "phpstan/phpstan": "2.1.54",
         "mockery/mockery": "^1.6.10",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5.35"
     },
     "autoload": {
         "psr-4": {
@@ -63,5 +62,13 @@
     "support": {
         "issues": "https://github.com/avto-dev/back2front-laravel/issues",
         "source": "https://github.com/avto-dev/back2front-laravel"
+    },
+    "config": {
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "report"
+            }
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
-        "phpstan/phpstan": "^1.10.66",
+        "phpstan/phpstan": "2.1.54",
         "mockery/mockery": "^1.6.5",
         "phpunit/phpunit": "^10.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/laravel": "^12.0 || ^13.0",
         "laravel/framework": "^12.0 || ^13.0",
         "phpstan/phpstan": "2.1.54",
-        "mockery/mockery": "^1.6.5",
+        "mockery/mockery": "^1.6.10",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "php": "^8.3",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/view": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/container": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/config": "^11.0 || ^12.0 || ^13.0"
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/view": "^12.0 || ^13.0",
+        "illuminate/container": "^12.0 || ^13.0",
+        "illuminate/config": "^12.0 || ^13.0"
     },
     "require-dev": {
         "laravel/laravel": "^12.0 || ^13.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "ext-mbstring": "*",
         "ext-json": "*",
         "illuminate/support": "^11.0 || ^12.0 || ^13.0",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "illuminate/config": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
-        "laravel/framework": "^11.54.0 || ^12.0 || ^13.0",
+        "laravel/laravel": "^12.0 || ^13.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "phpstan/phpstan": "2.1.54",
         "mockery/mockery": "^1.6.5",
         "phpunit/phpunit": "^10.5"

--- a/composer.json
+++ b/composer.json
@@ -62,13 +62,5 @@
     "support": {
         "issues": "https://github.com/avto-dev/back2front-laravel/issues",
         "source": "https://github.com/avto-dev/back2front-laravel"
-    },
-    "config": {
-        "policy": {
-            "advisories": {
-                "block": false,
-                "audit": "report"
-            }
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
+        "laravel/framework": "^11.54.0 || ^12.0 || ^13.0",
         "phpstan/phpstan": "2.1.54",
         "mockery/mockery": "^1.6.5",
         "phpunit/phpunit": "^10.5"

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/view": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/config": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/view": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/container": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/config": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "laravel/laravel": "^10.0 || ^11.0 || ^12.0",
+        "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
         "phpstan/phpstan": "^1.10.66",
         "mockery/mockery": "^1.6.5",
         "phpunit/phpunit": "^10.5"

--- a/src/Back2FrontInterface.php
+++ b/src/Back2FrontInterface.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * @extends Traversable<string, mixed>
- * @extends Arrayable<string, mixed>
+ * @extends Traversable<int|string, mixed>
+ * @extends Arrayable<int|string, mixed>
  */
 interface Back2FrontInterface extends Arrayable, Jsonable, Traversable, Countable
 {

--- a/src/Back2FrontStack.php
+++ b/src/Back2FrontStack.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Config\Repository as ConfigRepository;
 
 /**
- * @extends Collection<string, mixed>
+ * @extends Collection<int|string, mixed>
  */
 class Back2FrontStack extends Collection implements Back2FrontInterface
 {
@@ -55,7 +55,7 @@ class Back2FrontStack extends Collection implements Back2FrontInterface
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<int|string, mixed>
      */
     public function toArray(): array
     {
@@ -67,9 +67,9 @@ class Back2FrontStack extends Collection implements Back2FrontInterface
     /**
      * Recompiles the array only with simple data types and arrays.
      *
-     * @param mixed[] $data
+     * @param array<int|string, mixed> $data
      *
-     * @return array<mixed>
+     * @return array<int|string, mixed>
      */
     protected function clearNoScalarsFromArrayRecursive(array $data): array
     {
@@ -94,7 +94,7 @@ class Back2FrontStack extends Collection implements Back2FrontInterface
      * @param int             $depth     Текущая глубина обхода
      * @param int             $max_depth Максимальная глубина обхода
      *
-     * @return array<mixed>
+     * @return array<int|string, mixed>
      */
     protected function formatDataRecursive($data, $depth = 0, $max_depth = 3): array
     {


### PR DESCRIPTION
## Description

### Added

- Laravel `13.x` support

### Changed

- Minimal Laravel version now is `^11.0`
- Version of `composer` in docker container updated up to `2.10.0`
- Version of `php` in docker container updated up to `8.5`
- Minimal `phpunit/phpunit` version now is `^10.5.35`
- Update dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
